### PR TITLE
Switching the order of the calls and also logging the current url

### DIFF
--- a/src/middleware/ErrorMiddleware.coffee
+++ b/src/middleware/ErrorMiddleware.coffee
@@ -16,10 +16,11 @@ module.exports = (SpurErrors, Logger, HtmlErrorRender, BaseMiddleware, _)->
 
     middleware:(self)-> (err, req, res, next)=>
 
-      @logErrorStack(err)
-
       unless err.statusCode
         err = SpurErrors.InternalServerError.create(err.message, err)
+
+      @appendRequestData(err, req)
+      @logErrorStack(err)
 
       res.status(err.statusCode)
 
@@ -36,6 +37,12 @@ module.exports = (SpurErrors, Logger, HtmlErrorRender, BaseMiddleware, _)->
 
       unless _.contains(@EXCLUDE_STATUSCODE_FROM_LOGS, statusCode)
         Logger.error(err, "\n", err.stack, "\n", (err.data or ""))
+
+    appendRequestData: (err, req)->
+      err.data ?= {}
+      err.data = _.extend err.data, {
+        url: req.url
+      }
 
     sendTextResponse: (err, req, res)->
       res.send(err.message)

--- a/test/unit/middleware/ErrorMiddlewareSpec.coffee
+++ b/test/unit/middleware/ErrorMiddlewareSpec.coffee
@@ -34,6 +34,10 @@ describe "ErrorMiddleware", ->
             .set({'Accept': accept})
             .promise()
 
+      @assertError = (expectUrl)->
+        lastCall = @_.last(@Logger.recorded?.error)
+        expect(lastCall[4].url).to.equal expectUrl
+
   afterEach ()->
     @webServer?.stop().then =>
       expect(@_.last(@Logger.recorded.log)).to.deep.equal [
@@ -47,19 +51,19 @@ describe "ErrorMiddleware", ->
         expect(response.statusCode).to.equal(500)
         expect(@ErrorMiddleware.sendHtmlResponse.called).to.equal(true)
         expect(@HtmlErrorRender.render.called).to.equal(true)
-        expect(@Logger.recorded.error).to.exist
+        @assertError("/500-error-test")
 
     it "should attempt to render an json request", ->
       @sendRequest("application/json", @InternalServerError).error (response)=>
         expect(response.statusCode).to.equal(500)
         expect(@ErrorMiddleware.sendJsonResponse.called).to.equal(true)
-        expect(@Logger.recorded.error).to.exist
+        @assertError("/500-error-test")
 
     it "should attempt to render an text request", ->
       @sendRequest("text/plain", @InternalServerError).error (response)=>
         expect(response.statusCode).to.equal(500)
         expect(@ErrorMiddleware.sendTextResponse.called).to.equal(true)
-        expect(@Logger.recorded.error).to.exist
+        @assertError("/500-error-test")
 
   describe "server errors with standard throw", ->
 
@@ -68,19 +72,19 @@ describe "ErrorMiddleware", ->
         expect(response.statusCode).to.equal(500)
         expect(@ErrorMiddleware.sendHtmlResponse.called).to.equal(true)
         expect(@HtmlErrorRender.render.called).to.equal(true)
-        expect(@Logger.recorded.error).to.exist
+        @assertError("/500-standard-error-test")
 
     it "should attempt to render an json request", ->
       @sendRequest("application/json", @InternalServerStandardError).error (response)=>
         expect(response.statusCode).to.equal(500)
         expect(@ErrorMiddleware.sendJsonResponse.called).to.equal(true)
-        expect(@Logger.recorded.error).to.exist
+        @assertError("/500-standard-error-test")
 
     it "should attempt to render an text request", ->
       @sendRequest("text/plain", @InternalServerStandardError).error (response)=>
         expect(response.statusCode).to.equal(500)
         expect(@ErrorMiddleware.sendTextResponse.called).to.equal(true)
-        expect(@Logger.recorded.error).to.exist
+        @assertError("/500-standard-error-test")
 
   describe "not found errors", ->
 


### PR DESCRIPTION
Currently un-caught errors do not append the URL to the data being logged. In the cases where the logger is extended with a storage plugin, we want to be able to know the url it's being logged against.