### PR TITLE
Fixing the error middleware so that the logic is allowed to continue

### DIFF
--- a/src/middleware/ErrorMiddleware.coffee
+++ b/src/middleware/ErrorMiddleware.coffee
@@ -32,6 +32,8 @@ module.exports = (SpurErrors, Logger, HtmlErrorRender, BaseMiddleware, _)->
         json:()=>
           @sendJsonResponse(err, req, res)
 
+      next()
+
     logErrorStack: (err)->
       statusCode = err.statusCode or 0
 

--- a/test/fixtures/controllers/MockController.coffee
+++ b/test/fixtures/controllers/MockController.coffee
@@ -1,0 +1,8 @@
+module.exports = (BaseController)->
+
+  new class MockController extends BaseController
+
+    configure:(@app)->
+      super
+      @app.get "/", (req, res)-> res.status(200).send "SomeIndex"
+      @app.get "/with-error", (req, res)-> throw new Error("Throwing a basic error")


### PR DESCRIPTION
Currently winston logging is never updating the response status from 200 to 500 after an error occurs that is uncaught.

This is because the middleware if blocked from continuing.