### PR TITLE
Update express-winston to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cookie-parser": "^1.3.3",
     "express": "^4.11.1",
     "express-device": "^0.3.11",
-    "express-winston": "^0.2.12",
+    "express-winston": "^2.0.0",
     "method-override": "^2.3.1",
     "ejs": "^2.2.3",
     "coffee-script": "^1.9.1"


### PR DESCRIPTION
This is a pretty roundabout PR. I wanted to try out Yarn on `gc-microapp-profile`, but discovered that it refuses to install a package whose `engines` entry doesn't match the current one. Through some roundabout dependencies (see below), spur-web is depending on `hawk@0.10.2`, which requires `node@0.8.x`. This update should get things up to date.

All the tests still pass in this repo, and I tried the update within `gc-microapp-profile` without seeing anything off. You probably have a better idea of how to test this out.

```
├─┬ spur-web@0.1.7
│ └─┬ express-winston@0.2.12
│   └─┬ winston@0.7.3
│     └─┬ request@2.16.6
│       └── hawk@0.10.2
```