### PR TITLE
Porting the unit tests from coffee-script to es6

### DIFF
--- a/test/fixtures/injector.coffee
+++ b/test/fixtures/injector.coffee
@@ -16,6 +16,7 @@ module.exports = () ->
 
   ioc.registerFolders __dirname, [
     "controllers/",
+    "middleware/",
     "runtime/"
   ]
 

--- a/test/fixtures/middleware/TestBaseMiddleware.coffee
+++ b/test/fixtures/middleware/TestBaseMiddleware.coffee
@@ -1,0 +1,7 @@
+module.exports = (BaseMiddleware, Logger)->
+
+  new class TestBaseMiddleware extends BaseMiddleware
+
+    configure:()->
+      super
+      Logger.log 'Subclass called'

--- a/test/fixtures/runtime/TestWebServer.coffee
+++ b/test/fixtures/runtime/TestWebServer.coffee
@@ -11,5 +11,3 @@ module.exports = (BaseWebServer, Logger, path) ->
 
       @app.set('view engine', 'ejs')
       @app.set('views', path.join(__dirname, "../views"))
-
-    registerLoggingMiddleware: ->

--- a/test/fixtures/runtime/TestWebServer.coffee
+++ b/test/fixtures/runtime/TestWebServer.coffee
@@ -1,6 +1,6 @@
 module.exports = (BaseWebServer, Logger, path) ->
 
-  new class WebServer extends BaseWebServer
+  new class TestWebServer extends BaseWebServer
 
     registerDefaultMiddleware: ->
       super
@@ -11,3 +11,5 @@ module.exports = (BaseWebServer, Logger, path) ->
 
       @app.set('view engine', 'ejs')
       @app.set('views', path.join(__dirname, "../views"))
+
+    registerLoggingMiddleware: ->

--- a/test/legacy/middleware/ErrorMiddlewareSpec.coffee
+++ b/test/legacy/middleware/ErrorMiddlewareSpec.coffee
@@ -6,7 +6,7 @@ describe "ErrorMiddleware", ->
 
     nock.enableNetConnect()
 
-    injector().inject (@ErrorMiddleware, @HTTPService, @BaseWebServer, @HtmlErrorRender, @Logger, @config, @_)=>
+    injector().inject (@ErrorMiddleware, @HTTPService, @TestWebServer, @HtmlErrorRender, @Logger, @config, @_)=>
       @mockPort = 9080
 
       sinon.spy @HtmlErrorRender, "render"
@@ -19,13 +19,11 @@ describe "ErrorMiddleware", ->
       @NotFoundError = "http://localhost:#{@mockPort}/404-error-test"
       @NotFoundErrorUndefined = "http://localhost:#{@mockPort}/cant-find-this-path"
 
-      @webServer = new class WebServer extends @BaseWebServer
-        registerLoggingMiddleware:()->
 
       @startServerOnPort = (port)=>
         @config.Port = port
         @Logger.useRecorder()
-        @webServer.start()
+        @TestWebServer.start()
 
       @sendRequest = (accept, url)->
         @startServerOnPort(@mockPort).then =>
@@ -39,7 +37,7 @@ describe "ErrorMiddleware", ->
         expect(lastCall[4].url).to.equal expectUrl
 
   afterEach ()->
-    @webServer?.stop().then =>
+    @TestWebServer?.stop().then =>
       expect(@_.last(@Logger.recorded.info)).to.deep.equal [
         "Express server stopped"
       ]

--- a/test/legacy/middleware/PromiseMiddlewareSpec.coffee
+++ b/test/legacy/middleware/PromiseMiddlewareSpec.coffee
@@ -2,7 +2,7 @@ describe "PromiseMiddleware", ->
 
   beforeEach (done)->
     injector()
-    .inject (@WebServer, @HTTPService, @Logger, @config) =>
+    .inject (@TestWebServer, @HTTPService, @Logger, @config) =>
       @Logger.useRecorder()
 
       @getResponse = (type) =>
@@ -10,10 +10,10 @@ describe "PromiseMiddleware", ->
         @HTTPService
           .get(url)
 
-      @WebServer.start().then(done)
+      @TestWebServer.start().then(done)
 
   afterEach ()->
-    @WebServer.stop()
+    @TestWebServer.stop()
 
   it "jsonAsync - success", (done) ->
     @getResponse("jsonasync").promise().then (response)=>

--- a/test/legacy/webserver/BaseWebServerSpec.coffee
+++ b/test/legacy/webserver/BaseWebServerSpec.coffee
@@ -1,12 +1,12 @@
 describe "BaseWebServer", ->
 
   beforeEach () ->
-    injector().inject (@WebServer, @config, @Utils, @HTTPService, @Logger, @_)=>
+    injector().inject (@TestWebServer, @config, @Utils, @HTTPService, @Logger, @_)=>
       @Logger.useRecorder()
-      @WebServer.start()
+      @TestWebServer.start()
 
   afterEach () ->
-    @WebServer.stop()
+    @TestWebServer.stop()
 
   it "get index", (done) ->
     @HTTPService.get("http://localhost:9088/").promise().then (res)=>

--- a/test/unit/middleware/BaseMiddlewareSpec.js
+++ b/test/unit/middleware/BaseMiddlewareSpec.js
@@ -1,0 +1,22 @@
+describe('BaseMiddleware', function () {
+  beforeEach(() => {
+    injector().inject((TestBaseMiddleware, Logger) => {
+      this.TestBaseMiddleware = TestBaseMiddleware;
+      this.Logger = Logger;
+
+      this.Logger.useRecorder();
+    });
+  });
+
+  it('should log subclass registration', () => {
+    this.TestBaseMiddleware.configure('app');
+
+    expect(this.Logger.recorded.log).to.deep.equal([
+      ['Subclass called']
+    ]);
+
+    expect(this.Logger.recorded.info).to.deep.equal([
+      ['Registering Middleware: TestBaseMiddleware']
+    ]);
+  });
+});

--- a/test/unit/middleware/DefaultMiddlewareSpec.js
+++ b/test/unit/middleware/DefaultMiddlewareSpec.js
@@ -1,0 +1,21 @@
+describe('DefaultMiddleware', function () {
+  beforeEach(() => {
+    injector().inject((DefaultMiddleware, Logger, express) => {
+      this.DefaultMiddleware = DefaultMiddleware;
+      this.Logger = Logger;
+      this.express = express;
+
+      this.Logger.useRecorder();
+    });
+  });
+
+  it('should define configure', () => {
+    expect(this.DefaultMiddleware.configure).to.exist;
+  });
+
+  it('should set app in the instance', () => {
+    const app = this.express();
+    this.DefaultMiddleware.configure(app);
+    expect(this.DefaultMiddleware.app).to.equal(app);
+  });
+});

--- a/test/unit/middleware/ErrorMiddlewareSpec.js
+++ b/test/unit/middleware/ErrorMiddlewareSpec.js
@@ -1,0 +1,158 @@
+describe('ErrorMiddleware', function () {
+  beforeEach(() => {
+    injector().inject((ErrorMiddleware, HTTPService,
+      TestWebServer, HtmlErrorRender, Logger, config, _) => {
+      this.ErrorMiddleware = ErrorMiddleware;
+      this.HTTPService = HTTPService;
+      this.TestWebServer = TestWebServer;
+      this.HtmlErrorRender = HtmlErrorRender;
+      this.Logger = Logger;
+      this.config = config;
+      this._ = _;
+
+      this.mockPort = 9080;
+
+      sinon.spy(this.HtmlErrorRender, 'render');
+      sinon.spy(this.ErrorMiddleware, 'sendTextResponse');
+      sinon.spy(this.ErrorMiddleware, 'sendHtmlResponse');
+      sinon.spy(this.ErrorMiddleware, 'sendJsonResponse');
+
+      const host = `http://localhost:${this.mockPort}`;
+      this.InternalServerError = `${host}/500-error-test`;
+      this.InternalServerStandardError = `${host}/500-standard-error-test`;
+      this.NotFoundError = `${host}/404-error-test`;
+      this.NotFoundErrorUndefined = `${host}/cant-find-this-path`;
+
+      this.startServerOnPort = (port) => {
+        this.config.Port = port;
+        this.Logger.useRecorder();
+        return this.TestWebServer.start();
+      };
+
+      this.sendRequest = (accept, url) => {
+        return this.startServerOnPort(this.mockPort).then(() => {
+          return this.HTTPService.get(url)
+            .set({ Accept: accept })
+            .promise();
+        });
+      };
+
+      this.assertError = (expectUrl) => {
+        const lastCall = this._.last(this.Logger.recorded.error);
+        expect(lastCall[4].url).to.equal(expectUrl);
+      };
+    });
+  });
+
+  afterEach(() => {
+    return this.TestWebServer.stop();
+  });
+
+  describe('server errors with SpurErrors', () => {
+    it('should attempt to render an html request', () => {
+      return this.sendRequest('text/html', this.InternalServerError).error((response) => {
+        expect(response.statusCode).to.equal(500);
+        expect(this.ErrorMiddleware.sendHtmlResponse.called).to.equal(true);
+        expect(this.HtmlErrorRender.render.called).to.equal(true);
+        this.assertError('/500-error-test');
+      });
+    });
+
+    it('should attempt to render an json request', () => {
+      return this.sendRequest('application/json', this.InternalServerError).error((response) => {
+        expect(response.statusCode).to.equal(500);
+        expect(this.ErrorMiddleware.sendJsonResponse.called).to.equal(true);
+        this.assertError('/500-error-test');
+      });
+    });
+
+    it('should attempt to render an text request', () => {
+      return this.sendRequest('text/plain', this.InternalServerError).error((response) => {
+        expect(response.statusCode).to.equal(500);
+        expect(this.ErrorMiddleware.sendTextResponse.called).to.equal(true);
+        this.assertError('/500-error-test');
+      });
+    });
+  });
+
+  describe('server errors with standard throw', () => {
+    it('should attempt to render an html request', () => {
+      return this.sendRequest('text/html', this.InternalServerStandardError).error((response) => {
+        expect(response.statusCode).to.equal(500);
+        expect(this.ErrorMiddleware.sendHtmlResponse.called).to.equal(true);
+        expect(this.HtmlErrorRender.render.called).to.equal(true);
+        this.assertError('/500-standard-error-test');
+      });
+    });
+
+    it('should attempt to render an json request', () => {
+      return this.sendRequest('application/json', this.InternalServerStandardError).error((response) => {
+        expect(response.statusCode).to.equal(500);
+        expect(this.ErrorMiddleware.sendJsonResponse.called).to.equal(true);
+        this.assertError('/500-standard-error-test');
+      });
+    });
+
+    it('should attempt to render an text request', () => {
+      return this.sendRequest('text/plain', this.InternalServerStandardError).error((response) => {
+        expect(response.statusCode).to.equal(500);
+        expect(this.ErrorMiddleware.sendTextResponse.called).to.equal(true);
+        this.assertError('/500-standard-error-test');
+      });
+    });
+  });
+
+  describe('not found errors', () => {
+    it('should attempt to render an html request', () => {
+      return this.sendRequest('text/html', this.NotFoundError).error((response) => {
+        expect(response.statusCode).to.equal(404);
+        expect(this.ErrorMiddleware.sendHtmlResponse.called).to.equal(true);
+        expect(this.HtmlErrorRender.render.called).to.equal(true);
+        expect(this.Logger.recorded.error).to.not.exist;
+      });
+    });
+
+    it('should attempt to render an json request', () => {
+      return this.sendRequest('application/json', this.NotFoundError).error((response) => {
+        expect(response.statusCode).to.equal(404);
+        expect(this.ErrorMiddleware.sendJsonResponse.called).to.equal(true);
+        expect(this.Logger.recorded.error).to.not.exist;
+      });
+    });
+
+    it('should attempt to render an text request', () => {
+      return this.sendRequest('text/plain', this.NotFoundError).error((response) => {
+        expect(response.statusCode).to.equal(404);
+        expect(this.ErrorMiddleware.sendTextResponse.called).to.equal(true);
+        expect(this.Logger.recorded.error).to.not.exist;
+      });
+    });
+  });
+
+  describe('not found errors from undefined', () => {
+    it('should attempt to render an html request', () => {
+      return this.sendRequest('text/html', this.NotFoundErrorUndefined).error((response) => {
+        expect(response.statusCode).to.equal(404);
+        expect(this.ErrorMiddleware.sendHtmlResponse.called).to.equal(true);
+        expect(this.HtmlErrorRender.render.called).to.equal(true);
+        expect(this.Logger.recorded.error).to.not.exist;
+      });
+    });
+
+    it('should attempt to render an json request', () => {
+      return this.sendRequest('application/json', this.NotFoundErrorUndefined).error((response) => {
+        expect(response.statusCode).to.equal(404);
+        expect(this.ErrorMiddleware.sendJsonResponse.called).to.equal(true);
+        expect(this.Logger.recorded.error).to.not.exist;
+      });
+    });
+
+    it('should attempt to render an text request', () => {
+      return this.sendRequest('text/plain', this.NotFoundErrorUndefined).error((response) => {
+        expect(response.statusCode).to.equal(404);
+        expect(this.ErrorMiddleware.sendTextResponse.called).to.equal(true);
+        expect(this.Logger.recorded.error).to.not.exist;
+      });
+    });
+  });
+});

--- a/test/unit/middleware/NoCacheMiddlewareSpec.js
+++ b/test/unit/middleware/NoCacheMiddlewareSpec.js
@@ -1,0 +1,11 @@
+describe('NoCacheMiddleware', function () {
+  beforeEach(() => {
+    injector().inject((NoCacheMiddleware) => {
+      this.NoCacheMiddleware = NoCacheMiddleware;
+    });
+  });
+
+  it('should exist', () => {
+    expect(this.NoCacheMiddleware).to.exist;
+  });
+});

--- a/test/unit/middleware/PromiseMiddlewareSpec.js
+++ b/test/unit/middleware/PromiseMiddlewareSpec.js
@@ -1,0 +1,45 @@
+describe('PromiseMiddleware', function () {
+  beforeEach(() => {
+    injector().inject((TestWebServer, HTTPService, Logger, config) => {
+      this.TestWebServer = TestWebServer;
+      this.HTTPService = HTTPService;
+      this.Logger = Logger;
+      this.config = config;
+
+      this.Logger.useRecorder();
+
+      this.getResponse = (type) => {
+        const url = `http://localhost:${this.config.Port}/promise-middleware-test--${type}`;
+        return this.HTTPService.get(url);
+      };
+
+      return this.TestWebServer.start();
+    });
+  });
+
+  afterEach(() => {
+    return this.TestWebServer.stop();
+  });
+
+  it('jsonAsync - success', () => {
+    return this.getResponse('jsonasync').promise().then((response) => {
+      expect(response.type).to.equal('application/json');
+      expect(response.body).to.equal('jsonAsync success');
+    });
+  });
+
+  it('renderAsync - success', () => {
+    return this.getResponse('renderasync').promise().then((response) => {
+      expect(response.type).to.equal('text/html');
+      expect(response.text).to.contain('renderView from ejs: renderAsync success');
+    });
+  });
+
+  it('sendStatusAsync - success', () => {
+    return this.getResponse('sendstatusasync').promise().then((response) => {
+      expect(response.type).to.equal('text/plain');
+      expect(response.status).to.equal(200);
+      expect(response.text).to.equal('OK');
+    });
+  });
+});

--- a/test/unit/middleware/WinstonRequestLoggingMiddlewareSpec.js
+++ b/test/unit/middleware/WinstonRequestLoggingMiddlewareSpec.js
@@ -1,0 +1,169 @@
+/* eslint-disable no-unused-vars */
+
+describe('WinstonRequestLoggingMiddleware', function () {
+  beforeEach(() => {
+    this.MockPort = 9088;
+
+    injector().inject((WinstonRequestLoggingMiddleware, expressWinston, express,
+      HTTPService, Logger, config, _, colors, TestWebServer) => {
+      this.WinstonRequestLoggingMiddleware = WinstonRequestLoggingMiddleware;
+      this.expressWinston = expressWinston;
+      this.express = express;
+      this.HTTPService = HTTPService;
+      this.Logger = Logger;
+      this.config = config;
+      this._ = _;
+      this.colors = colors;
+      this.TestWebServer = TestWebServer;
+
+      sinon.spy(this.expressWinston, 'logger');
+      this.app = this.express();
+      this.Logger.useNoop();
+    });
+  });
+
+  afterEach(() => {
+    return this.expressWinston.logger.restore();
+  });
+
+  describe('configure() with defaults', () => {
+    beforeEach(() => {
+      this.WinstonRequestLoggingMiddleware.configure(this.app);
+      this.instanceConfig = this.WinstonRequestLoggingMiddleware.config;
+      this.options = this.WinstonRequestLoggingMiddleware.options;
+    });
+
+    it('should use empty config', () => {
+      expect(this.instanceConfig).to.deep.equal({});
+    });
+
+    it('should use the logger as the winston instance', () => {
+      expect(this.options.winstonInstance).to.equal(this.Logger);
+    });
+
+    it('should use default options', () => {
+      expect(this.options.meta).to.equal(true);
+      expect(this.options.expressFormat).to.equal(true);
+      expect(this.options.colorStatus).to.equal(true);
+    });
+
+    it('should call expressWinston.logger with options', () => {
+      expect(this.expressWinston.logger.getCall(0).args[0]).to.deep.equal(this.options);
+    });
+  });
+
+  describe('configure() with custom config', () => {
+    beforeEach(() => {
+      this.config.WinstonWebLogging = {
+        meta: false,
+        expressFormat: false,
+        colorStatus: false,
+        fakeOption: '123'
+      };
+
+      this.WinstonRequestLoggingMiddleware.configure(this.app);
+      this.instanceConfig = this.WinstonRequestLoggingMiddleware.config;
+      this.options = this.WinstonRequestLoggingMiddleware.options;
+    });
+
+    it('should use the logger as the winston instance', () => {
+      expect(this.options.winstonInstance).to.equal(this.Logger);
+    });
+
+    it('should use custom options', () => {
+      expect(this.options.meta).to.equal(false);
+      expect(this.options.expressFormat).to.equal(false);
+      expect(this.options.colorStatus).to.equal(false);
+    });
+
+    it('should add a non-default option', () => {
+      expect(this.options.fakeOption).to.equal('123');
+    });
+
+    it('should call expressWinston.logger with options', () => {
+      expect(this.expressWinston.logger.getCall(0).args[0]).to.deep.equal(this.options);
+    });
+  });
+
+  describe('with request', () => {
+    beforeEach(() => {
+      this.startServer = () => {
+        this.Logger.useRecorder();
+        return this.TestWebServer.start();
+      };
+    });
+
+    afterEach(() => {
+      return this.TestWebServer.stop();
+    });
+
+    it('should log a winston request with json meta', () => {
+      return this.startServer().then(() => {
+        return this.HTTPService.get('http://localhost:9088').promise().then((res) => {
+          const lastEntry = this._.last(this.Logger.recorded.log);
+          const message = this.colors.strip(lastEntry[1]);
+          const data = lastEntry[2];
+
+          const expectedData = {
+            req: {
+              headers: {
+                'accept-encoding': 'gzip, deflate',
+                connection: 'close',
+                host: 'localhost:9088'
+              },
+              httpVersion: '1.1',
+              method: 'GET',
+              originalUrl: '/',
+              query: {},
+              url: '/'
+            },
+            res: {
+              statusCode: 200
+            },
+            responseTime: data.responseTime
+          };
+
+          delete data.req.headers['user-agent'];
+
+          expect(lastEntry[0]).to.equal('info');
+          expect(message).to.equal(`GET / 200 ${data.responseTime}ms`);
+          expect(data).to.deep.equal(expectedData);
+        });
+      });
+    });
+
+    it('should log a winston request without meta', () => {
+      this.config.WinstonWebLogging = { expressFormat: true, meta: false };
+
+      return this.startServer().then(() => {
+        return this.HTTPService.get('http://localhost:9088').promise().then((res) => {
+          const lastEntry = this._.last(this.Logger.recorded.log);
+          const message = this.colors.strip(lastEntry[1]);
+          const data = lastEntry[2];
+          const expectedData = {};
+
+          expect(lastEntry[0]).to.equal('info');
+          expect(message).to.contain('GET / 200');
+          expect(data).to.deep.equal(expectedData);
+        });
+      });
+    });
+
+    it('should log a winston request with meta for error', () => {
+      this.config.WinstonWebLogging = { expressFormat: true, meta: false };
+
+      return this.startServer().then(() => {
+        return this.HTTPService.get('http://localhost:9088/with-error').promise().error((res) => {
+          const lastEntry = this._.last(this.Logger.recorded.log);
+          const message = this.colors.strip(lastEntry[1]);
+          const data = lastEntry[2];
+          const expectedData = {};
+
+          expect(lastEntry[0]).to.equal('info');
+          expect(message).to.contain('GET /with-error 500');
+          expect(data).to.deep.equal(expectedData);
+        });
+      });
+    });
+  });
+});

--- a/test/unit/webserver/BaseWebServerSpec.js
+++ b/test/unit/webserver/BaseWebServerSpec.js
@@ -1,12 +1,10 @@
 describe('BaseWebServer', function () {
   beforeEach(() => {
-    injector().inject((WebServer, config, Utils, HTTPService, Logger, _) => {
+    injector().inject((WebServer, config, HTTPService, Logger) => {
       this.WebServer = WebServer;
       this.config = config;
-      this.Utils = Utils;
       this.HTTPService = HTTPService;
       this.Logger = Logger;
-      this._ = _;
 
       this.Logger.useRecorder();
 

--- a/test/unit/webserver/BaseWebServerSpec.js
+++ b/test/unit/webserver/BaseWebServerSpec.js
@@ -1,19 +1,19 @@
-describe('BaseWebServer', function () {
+describe('BaseTestWebServer', function () {
   beforeEach(() => {
-    injector().inject((WebServer, config, HTTPService, Logger) => {
-      this.WebServer = WebServer;
+    injector().inject((TestWebServer, config, HTTPService, Logger) => {
+      this.TestWebServer = TestWebServer;
       this.config = config;
       this.HTTPService = HTTPService;
       this.Logger = Logger;
 
       this.Logger.useRecorder();
 
-      this.WebServer.start();
+      this.TestWebServer.start();
     });
   });
 
   afterEach(() => {
-    this.WebServer.stop();
+    this.TestWebServer.stop();
   });
 
   it('get index', (done) => {


### PR DESCRIPTION
Still maintaining the CoffeeScript tests in a separate directory just to verified that the tests continue to work after the porting of the `src/` files.