### PR TITLE
Addressing vulnerability caused by express-device@0.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spur-web",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "description": "Common node modules and express middleware that are designed to be the boilerplate of a node web app.",
   "main": "lib/injector",
   "jsnext:main": "./src/injector",
@@ -58,7 +58,7 @@
     "cookie-parser": "^1.3.3",
     "ejs": "^2.2.3",
     "express": "^4.11.1",
-    "express-device": "^0.3.11",
+    "express-device": "^0.4.2",
     "express-winston": "^2.0.0",
     "method-override": "^2.3.1",
     "spur-ioc": "^0.2.4",


### PR DESCRIPTION
**This is mainly to resolve the snyk report. The semversion was already setup to solve this issue.**

### [Prototype Override Protection Bypass](https://snyk.io/vuln/npm:qs:20170213)

Vulnerable module: qs
Introduced through: express-device@0.3.13

**Detailed paths:**

* Introduced through: spur-web@1.0.0 › express-device@0.3.13 › express@3.21.2 › connect@2.30.2 › qs@4.0.0
* Introduced through: spur-web@1.0.0 › express-device@0.3.13 › express@3.21.2 › connect@2.30.2 › body-parser@1.13.3 › qs@4.0.0

### [Regular Expression Denial of Service (DoS)](https://snyk.io/vuln/npm:negotiator:20160616)

Vulnerable module: negotiator
Introduced through: express-device@0.3.13

**Detailed paths:**

* Introduced through: spur-web@1.0.0 › express-device@0.3.13 › express@3.21.2 › connect@2.30.2 › compression@1.5.2 › accepts@1.2.13 › negotiator@0.5.3
* Introduced through: spur-web@1.0.0 › express-device@0.3.13 › express@3.21.2 › connect@2.30.2 › serve-index@1.7.3 › accepts@1.2.13 › negotiator@0.5.3

---

Also correcting the package version.