### PR TITLE
Breaking change: Removes the EJS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,33 +80,12 @@ module.exports = function (BaseWebServer, path) {
     // Add additional changes to the middleware by overriding the method
     registerDefaultMiddleware() {
       super.registerDefaultMiddleware();
-      this.registerEjsTemplates();
-    }
-
-    registerEjsTemplates() {
-      this.logSectionHeader('EJS Template Registration');
-
-      this.app.set('view engine', 'ejs');
-      this.app.set('views', path.join(__dirname, '../views'));
     }
   }
 
   // Assure there is just one instance
   return new WebServer();
 };
-```
-
-#### `src/views/hello.ejs`
-
-```html
-<html>
-  <head>
-     <meta charset="utf-8">
-  </head>
-<body>
-  <h1><%= user %></h1>
-</body>
-</html>
 ```
 
 #### `src/controllers/HelloController.js`
@@ -129,11 +108,7 @@ module.exports = function (BaseController) {
     }
 
     getHello(req, res) {
-      const model = {
-        user: req.query.user || 'John Doe'
-      };
-
-      res.render('hello', model);
+      res.send('hello');
     }
 
   }
@@ -184,7 +159,6 @@ List of external dependencies used and exposed by spur-web. They can be found at
 | **cookieParser**   | [cookie-parser](https://www.npmjs.org/package/cookie-parser)     |
 | **bodyParser**     | [body-parser](https://www.npmjs.org/package/body-parser)         |
 | **expressWinston** | [express-winston](https://www.npmjs.org/package/express-winston) |
-| **ejs**            | [ejs](https://www.npmjs.org/package/ejs)                         |
 
 ### Local dependecies
 

--- a/example/src/runtime/WebServer.js
+++ b/example/src/runtime/WebServer.js
@@ -1,18 +1,11 @@
-module.exports = function (BaseWebServer, path) {
+module.exports = function (BaseWebServer) {
   class WebServer extends BaseWebServer {
 
     // Add additional changes to the middleware by overriding the method
     registerDefaultMiddleware() {
       super.registerDefaultMiddleware();
-      this.registerEjsTemplates();
     }
 
-    registerEjsTemplates() {
-      this.logSectionHeader('EJS Template Registration');
-
-      this.app.set('view engine', 'ejs');
-      this.app.set('views', path.join(__dirname, '../views'));
-    }
   }
 
   // Assure there is just one instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "body-parser": "^1.20.0",
         "cookie-parser": "^1.4.6",
-        "ejs": "^3.1.8",
         "express": "^4.18.1",
         "express-device": "^0.4.2",
         "express-winston": "^2.6.0",
@@ -364,7 +363,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -408,6 +408,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -650,7 +651,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -834,20 +836,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1370,33 +1358,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1892,23 +1853,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "node_modules/jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2232,6 +2176,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3819,7 +3764,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -3856,6 +3802,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4049,7 +3996,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -4187,14 +4135,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
-      "requires": {
-        "jake": "^10.8.5"
-      }
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -4591,32 +4531,6 @@
         "flat-cache": "^3.0.4"
       }
     },
-    "filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "requires": {
-        "minimatch": "^5.0.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4972,17 +4886,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
-      "requires": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
-      }
-    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -5265,6 +5168,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "body-parser": "^1.20.0",
     "cookie-parser": "^1.4.6",
-    "ejs": "^3.1.8",
     "express": "^4.18.1",
     "express-device": "^0.4.2",
     "express-winston": "^2.6.0",

--- a/src/injector.js
+++ b/src/injector.js
@@ -6,7 +6,6 @@ const methodOverride = require('method-override');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const expressWinston = require('express-winston');
-const ejs = require('ejs');
 
 module.exports = function injector() {
   const ioc = spur.create('spur-web');
@@ -17,8 +16,7 @@ module.exports = function injector() {
     methodOverride,
     cookieParser,
     bodyParser,
-    expressWinston,
-    ejs
+    expressWinston
   });
 
   ioc.registerFolders(__dirname, [

--- a/test/fixtures/runtime/TestWebServer.js
+++ b/test/fixtures/runtime/TestWebServer.js
@@ -1,18 +1,11 @@
-module.exports = function (BaseWebServer, Logger, path) {
+module.exports = function (BaseWebServer) {
 
   class TestWebServer extends BaseWebServer {
 
     registerDefaultMiddleware(){
       super.registerDefaultMiddleware();
-      this.registerEjsTemplates();
     }
 
-    registerEjsTemplates() {
-      Logger.log('EJS Template Registration');
-
-      this.app.set('view engine', 'ejs');
-      this.app.set('views', path.join(__dirname, '../views'));
-    }
   }
 
   return new TestWebServer();

--- a/test/fixtures/views/renderView.ejs
+++ b/test/fixtures/views/renderView.ejs
@@ -1,1 +1,0 @@
-renderView from ejs: <%= microapp %>

--- a/test/integration/ModuleIntegration_Spec.js
+++ b/test/integration/ModuleIntegration_Spec.js
@@ -12,14 +12,13 @@ describe('Integration', () => {
 
     describe('base dependencies', () => {
       it('base module dependencies are injectable', function () {
-        this.ioc.inject(function (express, expressDevice, methodOverride, cookieParser, bodyParser, expressWinston, ejs) {
+        this.ioc.inject(function (express, expressDevice, methodOverride, cookieParser, bodyParser, expressWinston) {
           expect(express).to.exist;
           expect(expressDevice).to.exist;
           expect(methodOverride).to.exist;
           expect(cookieParser).to.exist;
           expect(bodyParser).to.exist;
           expect(expressWinston).to.exist;
-          expect(ejs).to.exist;
         });
       });
     });

--- a/test/unit/middleware/PromiseMiddlewareSpec.js
+++ b/test/unit/middleware/PromiseMiddlewareSpec.js
@@ -29,14 +29,6 @@ describe('PromiseMiddleware', function () {
       expect(response.body).to.equal('jsonAsync success');
     });
   });
-
-  it('renderAsync - success', () => {
-    return base.getResponse('renderasync').promise().then((response) => {
-      expect(response.type).to.equal('text/html');
-      expect(response.text).to.contain('renderView from ejs: renderAsync success');
-    });
-  });
-
   it('sendStatusAsync - success', () => {
     return base.getResponse('sendstatusasync').promise().then((response) => {
       expect(response.type).to.equal('text/plain');


### PR DESCRIPTION
This low-level dependency should that doesn't directly use EJS and should not control which version it exposes. Having this here, forces the dependents to use this version and makes it overly complicated to update and fix security issues with ejs.